### PR TITLE
 Convert back to map[string]string

### DIFF
--- a/api/general.go
+++ b/api/general.go
@@ -19,7 +19,7 @@ func (api *API) InitGeneral() {
 }
 
 func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte(model.StringInterfaceToJson(utils.ClientCfg)))
+	w.Write([]byte(model.MapToJson(utils.ClientCfg)))
 }
 
 func logClient(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/system.go
+++ b/api4/system.go
@@ -243,14 +243,14 @@ func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respCfg := make(map[string]interface{})
+	respCfg := make(map[string]string)
 	for k, v := range utils.ClientCfg {
 		respCfg[k] = v
 	}
 
 	respCfg["NoAccounts"] = strconv.FormatBool(c.App.IsFirstUserAccount())
 
-	w.Write([]byte(model.StringInterfaceToJson(respCfg)))
+	w.Write([]byte(model.MapToJson(respCfg)))
 }
 
 func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/system.go
+++ b/api4/system.go
@@ -243,7 +243,7 @@ func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respCfg := map[string]string
+	respCfg := map[string]string{}
 	for k, v := range utils.ClientCfg {
 		respCfg[k] = v
 	}

--- a/api4/system.go
+++ b/api4/system.go
@@ -243,7 +243,7 @@ func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respCfg := make(map[string]string)
+	respCfg := map[string]string
 	for k, v := range utils.ClientCfg {
 		respCfg[k] = v
 	}

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -997,9 +997,9 @@ func TestPatchUser(t *testing.T) {
 	patch.NotifyProps = model.StringMap{}
 	patch.NotifyProps["comment"] = "somethingrandom"
 	patch.Timezone = model.StringMap{}
-	patch.NotifyProps["useAutomaticTimezone"] = "true"
-	patch.NotifyProps["automaticTimezone"] = "America/New_York"
-	patch.NotifyProps["manualTimezone"] = ""
+	patch.Timezone["useAutomaticTimezone"] = "true"
+	patch.Timezone["automaticTimezone"] = "America/New_York"
+	patch.Timezone["manualTimezone"] = ""
 
 	ruser, resp := Client.PatchUser(user.Id, patch)
 	CheckNoError(t, resp)
@@ -1024,13 +1024,13 @@ func TestPatchUser(t *testing.T) {
 		t.Fatal("NotifyProps did not update properly")
 	}
 	if ruser.Timezone["useAutomaticTimezone"] != "true" {
-		t.Fatal("Timezone did not update properly")
+		t.Fatal("useAutomaticTimezone did not update properly")
 	}
 	if ruser.Timezone["automaticTimezone"] != "America/New_York" {
-		t.Fatal("Timezone did not update properly")
+		t.Fatal("automaticTimezone did not update properly")
 	}
 	if ruser.Timezone["manualTimezone"] != "" {
-		t.Fatal("Timezone did not update properly")
+		t.Fatal("manualTimezone did not update properly")
 	}
 
 	patch.Username = model.NewString(th.BasicUser2.Username)

--- a/app/app.go
+++ b/app/app.go
@@ -64,7 +64,6 @@ type App struct {
 
 	pluginCommands     []*PluginCommand
 	pluginCommandsLock sync.RWMutex
-	clientConfig       map[string]interface{}
 }
 
 var appCount = 0
@@ -84,7 +83,6 @@ func New(options ...Option) *App {
 		},
 		sessionCache: utils.NewLru(model.SESSION_CACHE_SIZE),
 		configFile:   "config.json",
-		clientConfig: make(map[string]interface{}),
 	}
 
 	for _, option := range options {

--- a/model/initial_load.go
+++ b/model/initial_load.go
@@ -9,13 +9,13 @@ import (
 )
 
 type InitialLoad struct {
-	User        *User                  `json:"user"`
-	TeamMembers []*TeamMember          `json:"team_members"`
-	Teams       []*Team                `json:"teams"`
-	Preferences Preferences            `json:"preferences"`
-	ClientCfg   map[string]interface{} `json:"client_cfg"`
-	LicenseCfg  map[string]string      `json:"license_cfg"`
-	NoAccounts  bool                   `json:"no_accounts"`
+	User        *User             `json:"user"`
+	TeamMembers []*TeamMember     `json:"team_members"`
+	Teams       []*Team           `json:"teams"`
+	Preferences Preferences       `json:"preferences"`
+	ClientCfg   map[string]string `json:"client_cfg"`
+	LicenseCfg  map[string]string `json:"license_cfg"`
+	NoAccounts  bool              `json:"no_accounts"`
 }
 
 func (me *InitialLoad) ToJson() string {

--- a/utils/config.go
+++ b/utils/config.go
@@ -42,7 +42,7 @@ var CfgHash = ""
 var ClientCfgHash = ""
 var CfgFileName string = ""
 var CfgDisableConfigWatch = false
-var ClientCfg map[string]interface{}
+var ClientCfg map[string]string = map[string]string{}
 var originalDisableDebugLvl l4g.Level = l4g.DEBUG
 var siteURL = ""
 
@@ -437,8 +437,8 @@ func RegenerateClientConfig() {
 	ClientCfg = getClientConfig(Cfg)
 }
 
-func getClientConfig(c *model.Config) map[string]interface{} {
-	props := make(map[string]interface{})
+func getClientConfig(c *model.Config) map[string]string {
+	props := make(map[string]string)
 
 	props["Version"] = model.CurrentVersion
 	props["BuildNumber"] = model.BuildNumber
@@ -552,7 +552,7 @@ func getClientConfig(c *model.Config) map[string]interface{} {
 
 	props["PluginsEnabled"] = strconv.FormatBool(*c.PluginSettings.Enable)
 	props["EnableTimezoneSelection"] = strconv.FormatBool(*c.DisplaySettings.EnableTimezoneSelection)
-	props["SupportedTimezones"] = c.SupportedTimezones
+	props["SupportedTimezones"] = strings.Join(c.SupportedTimezones, ",")
 
 	if IsLicensed() {
 		License := License()


### PR DESCRIPTION

Convert back to map[string]string when sending configs to clients

SupportedTimezones gets serialized now. The web client has the changes for this