### PR TITLE
UCHAT-171 Localize timestamps in email notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -359,15 +359,21 @@ func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel 
 		// fall back to sending a single email if we can't batch it for some reason
 	}
 
+	var useMilitaryTime bool
 	translateFunc := utils.GetUserTranslations(user.Locale)
+	if result := <-a.Srv.Store.Preference().Get(user.Id, model.PREFERENCE_CATEGORY_DISPLAY_SETTINGS, "use_military_time"); result.Err != nil {
+		useMilitaryTime = true
+	} else {
+		useMilitaryTime = result.Data.(model.Preference).Value == "true"
+	}
 
 	var subjectText string
 	if channel.Type == model.CHANNEL_DIRECT {
-		subjectText = getDirectMessageNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, senderName)
+		subjectText = getDirectMessageNotificationEmailSubject(user, post, translateFunc, a.Config().TeamSettings.SiteName, senderName, useMilitaryTime)
 	} else if *a.Config().EmailSettings.UseChannelInEmailNotifications {
-		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName+" ("+channel.DisplayName+")")
+		subjectText = getNotificationEmailSubject(user, post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName+" ("+channel.DisplayName+")", useMilitaryTime)
 	} else {
-		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName)
+		subjectText = getNotificationEmailSubject(user, post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName, useMilitaryTime)
 	}
 
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_FULL
@@ -376,7 +382,7 @@ func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel 
 	}
 
 	teamURL := a.GetSiteURL() + "/" + team.Name
-	var bodyText = a.getNotificationEmailBody(user, post, channel, senderName, team.Name, teamURL, emailNotificationContentsType, translateFunc)
+	var bodyText = a.getNotificationEmailBody(user, post, channel, senderName, team.Name, teamURL, emailNotificationContentsType, useMilitaryTime, translateFunc)
 
 	a.Go(func() {
 		if err := a.SendMail(user.Email, html.UnescapeString(subjectText), bodyText); err != nil {
@@ -394,8 +400,9 @@ func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel 
 /**
  * Computes the subject line for direct notification email messages
  */
-func getDirectMessageNotificationEmailSubject(post *model.Post, translateFunc i18n.TranslateFunc, siteName string, senderName string) string {
+func getDirectMessageNotificationEmailSubject(user *model.User, post *model.Post, translateFunc i18n.TranslateFunc, siteName string, senderName string, useMilitaryTime bool) string {
 	t := getFormattedPostTime(post, translateFunc)
+	t = getLocalTime(user, t, useMilitaryTime, translateFunc)
 	var subjectParameters = map[string]interface{}{
 		"SiteName":          siteName,
 		"SenderDisplayName": senderName,
@@ -409,8 +416,9 @@ func getDirectMessageNotificationEmailSubject(post *model.Post, translateFunc i1
 /**
  * Computes the subject line for group, public, and private email messages
  */
-func getNotificationEmailSubject(post *model.Post, translateFunc i18n.TranslateFunc, siteName string, teamName string) string {
+func getNotificationEmailSubject(user *model.User, post *model.Post, translateFunc i18n.TranslateFunc, siteName string, teamName string, useMilitaryTime bool) string {
 	t := getFormattedPostTime(post, translateFunc)
+	t = getLocalTime(user, t, useMilitaryTime, translateFunc)
 	var subjectParameters = map[string]interface{}{
 		"SiteName": siteName,
 		"TeamName": teamName,
@@ -424,7 +432,7 @@ func getNotificationEmailSubject(post *model.Post, translateFunc i18n.TranslateF
 /**
  * Computes the email body for notification messages
  */
-func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, channel *model.Channel, senderName string, teamName string, teamURL string, emailNotificationContentsType string, translateFunc i18n.TranslateFunc) string {
+func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, channel *model.Channel, senderName string, teamName string, teamURL string, emailNotificationContentsType string, useMilitaryTime bool, translateFunc i18n.TranslateFunc) string {
 	// only include message contents in notification email if email notification contents type is set to full
 	var bodyPage *utils.HTMLTemplate
 	if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
@@ -446,6 +454,7 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 		channelName = translateFunc("api.templates.channel_name.group")
 	}
 	t := getFormattedPostTime(post, translateFunc)
+	t = getLocalTime(recipient, t, useMilitaryTime, translateFunc)
 
 	var bodyText string
 	var info template.HTML
@@ -530,6 +539,38 @@ func getFormattedPostTime(post *model.Post, translateFunc i18n.TranslateFunc) fo
 		Day:      fmt.Sprintf("%d", tm.Day()),
 		Hour:     fmt.Sprintf("%02d", tm.Hour()),
 		Minute:   fmt.Sprintf("%02d", tm.Minute()),
+		TimeZone: zone,
+	}
+}
+
+func getLocalTime(user *model.User, postTime formattedPostTime, useMilitaryTime bool, translateFunc i18n.TranslateFunc) formattedPostTime {
+	preferredTimezone := user.GetPreferredTimezone()
+	if preferredTimezone == "" {
+		return postTime
+	}
+
+	loc, err := time.LoadLocation(preferredTimezone)
+	if err != nil {
+		return postTime
+	}
+
+	localTime := postTime.Time.In(loc)
+	zone, _ := localTime.Zone()
+
+	hour := localTime.Format("15")
+	period := ""
+	if !useMilitaryTime {
+		hour = localTime.Format("3")
+		period = " " + localTime.Format("PM")
+	}
+
+	return formattedPostTime{
+		Time:     localTime,
+		Year:     fmt.Sprintf("%d", localTime.Year()),
+		Month:    translateFunc(localTime.Month().String()),
+		Day:      fmt.Sprintf("%d", localTime.Day()),
+		Hour:     fmt.Sprintf("%s", hour),
+		Minute:   fmt.Sprintf("%02d"+period, localTime.Minute()),
 		TimeZone: zone,
 	}
 }

--- a/model/user.go
+++ b/model/user.go
@@ -481,6 +481,14 @@ func (u *User) IsSAMLUser() bool {
 	return u.AuthService == USER_AUTH_SERVICE_SAML
 }
 
+func (u *User) GetPreferredTimezone() string {
+	if u.Timezone["useAutomaticTimezone"] == "true" {
+		return u.Timezone["automaticTimezone"]
+	}
+
+	return u.Timezone["manualTimezone"]
+}
+
 // UserFromJson will decode the input and return a User
 func UserFromJson(data io.Reader) *User {
 	var user *User


### PR DESCRIPTION
#### Summary
Add localized timestamp support for email notifications
Also, added support to respec `use_military_time` preference

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-171

#### Screenshots
<img width="316" alt="screen shot 2018-04-24 at 5 40 43 pm" src="https://user-images.githubusercontent.com/6182543/39257045-81b1e2a2-487e-11e8-80dc-ff45a01eacbe.png">
<img width="294" alt="screen shot 2018-04-24 at 5 33 39 pm" src="https://user-images.githubusercontent.com/6182543/39257046-81c9e3ca-487e-11e8-8e9a-3cb8f6116d9b.png">

* User timezone set to **America/Denver** . 
* Time from screenshot 3pm Denver vs 5pm NewYork

**Direct Message**
**12 Hour Format**
<img width="694" alt="screen shot 2018-04-24 at 5 32 45 pm" src="https://user-images.githubusercontent.com/6182543/39256713-998922f6-487d-11e8-91d6-02a5a04f375f.png">

**24 Hour Format**
<img width="683" alt="screen shot 2018-04-24 at 5 33 59 pm" src="https://user-images.githubusercontent.com/6182543/39256711-994cd4fe-487d-11e8-8006-062d9c5b0ece.png">

**Group Message**
<img width="692" alt="screen shot 2018-04-24 at 5 32 53 pm" src="https://user-images.githubusercontent.com/6182543/39256712-99682088-487d-11e8-8e7b-6a0a5126c209.png">
**Public Channel**
<img width="684" alt="screen shot 2018-04-24 at 5 36 49 pm" src="https://user-images.githubusercontent.com/6182543/39256710-9925c76a-487d-11e8-92cd-784d3a2d8473.png">
**Private Channel**
<img width="684" alt="screen shot 2018-04-24 at 5 36 59 pm" src="https://user-images.githubusercontent.com/6182543/39256709-990fb920-487d-11e8-93f6-9319837e5472.png">



