### PR TITLE
UCHAT-4566 Send email to all channel members with 1-click.

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2715,3 +2715,38 @@ func TestGetChannelMembersTimezones(t *testing.T) {
 	}
 
 }
+
+func TestGetChannelMembersEmails(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	Client := th.Client
+	channel := th.CreatePrivateChannel()
+
+	emailIds, resp := Client.GetChannelMembersEmails(channel.Id)
+	CheckNoError(t, resp)
+
+	if emailIds == "error" {
+		t.Fatal("couldnt't get extra info")
+	} else if strings.Index(emailIds, "@") == -1 {
+		t.Fatal("got incorrect member emails")
+	}
+
+	_, resp = Client.GetChannelMembersEmails("junk")
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.GetChannelMembersEmails(model.NewId())
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.GetChannelMembersEmails(channel.Id)
+	CheckUnauthorizedStatus(t, resp)
+
+	th.LoginBasic2()
+
+	_, resp = Client.GetChannelMembersEmails(channel.Id)
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.GetChannelMembersEmails(channel.Id)
+	CheckNoError(t, resp)
+
+}

--- a/app/channel.go
+++ b/app/channel.go
@@ -1329,6 +1329,21 @@ func (a *App) GetChannelMembersTimezones(channelId string) ([]string, *model.App
 	return model.RemoveDuplicateStrings(timezones), nil
 }
 
+func (a *App) GetChannelMembersEmails(channelId string) ([]string, *model.AppError) {
+	result := <-a.Srv.Store.Channel().GetChannelMembersEmails(channelId)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	var emails []string
+
+	members := result.Data.([]*model.ChannelMemberForExport)
+
+	for _, member := range members {
+		emails = append(emails, member.Username)
+	}
+	return emails, nil
+}
+
 func (a *App) GetChannelMembersByIds(channelId string, userIds []string) (*model.ChannelMembers, *model.AppError) {
 	result := <-a.Srv.Store.Channel().GetMembersByIds(channelId, userIds)
 	if result.Err != nil {

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -912,3 +912,37 @@ func TestDefaultChannelNames(t *testing.T) {
 	expect = []string{"town-square", "foo", "bar"}
 	require.ElementsMatch(t, expect, actual)
 }
+
+func TestGetChannelMembersEmails(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	userRequestorId := ""
+	postRootId := ""
+	if _, err := th.App.AddChannelMember(th.BasicUser2.Id, th.BasicChannel, userRequestorId, postRootId); err != nil {
+		t.Fatal("Failed to add user to channel. Error: " + err.Message)
+	}
+
+	user := th.BasicUser
+	th.App.UpdateUser(user, false)
+
+	user2 := th.BasicUser2
+	th.App.UpdateUser(user2, false)
+
+	user3 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	ruser, _ := th.App.CreateUser(&user3)
+	th.App.AddUserToChannel(ruser, th.BasicChannel)
+
+	ruser.Timezone["automaticTimezone"] = "NoWhere/Island"
+	th.App.UpdateUser(ruser, false)
+
+	user4 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	ruser, _ = th.App.CreateUser(&user4)
+	th.App.AddUserToChannel(ruser, th.BasicChannel)
+
+	email_ids, err := th.App.GetChannelMembersEmails(th.BasicChannel.Id)
+	if err != nil {
+		t.Fatal("Failed to get the member emails for a channel. Error: " + err.Error())
+	}
+	assert.Equal(t, 2, len(email_ids))
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -4412,3 +4412,13 @@ func (c *Client4) PatchGroupSyncable(groupID, syncableID string, syncableType Gr
 	defer closeBody(r)
 	return GroupSyncableFromJson(r.Body), BuildResponse(r)
 }
+
+// GetChannelMembersEmails gets a list of emails for a channel.
+func (c *Client4) GetChannelMembersEmails(channelId string) (string, *Response) {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/emails", "")
+	if err != nil {
+		return "error", BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return StringFromJson(r.Body), BuildResponse(r)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -163,6 +163,7 @@ type ChannelStore interface {
 	GetMembers(channelId string, offset, limit int) StoreChannel
 	GetMember(channelId string, userId string) (*model.ChannelMember, *model.AppError)
 	GetChannelMembersTimezones(channelId string) StoreChannel
+	GetChannelMembersEmails(channelId string) StoreChannel
 	GetAllChannelMembersForUser(userId string, allowFromCache bool, includeDeleted bool) StoreChannel
 	InvalidateAllChannelMembersForUser(userId string)
 	IsUserInChannelUseCache(userId string, channelId string) bool

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -1139,3 +1139,19 @@ func (_m *ChannelStore) UserBelongsToChannels(userId string, channelIds []string
 
 	return r0
 }
+
+// GetChannelMembersEmails provides a mock function with given fields: channelId
+func (_m *ChannelStore) GetChannelMembersEmails(channelId string) store.StoreChannel {
+	ret := _m.Called(channelId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(channelId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Send email to all channel members with 1-click.
In this PR created a new API which expects the channelid and returns the emailids of channel members separated by ",".

New endpoint will be like
http://localhost:8065/api/v4/channels/<<channel_id>>/emails

Output will be like

"ashish.kumar@uber.com,amit.m@uber.com"
<!--
A description of what this pull request does.
-->

#### Ticket Link

https://jira.uberinternal.com/browse/UCHAT-4566
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
