### PR TITLE
UCHAT-4659 API to send push notification alerts to active mobile users

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -223,6 +223,7 @@ func Init(configservice configservice.ConfigService, globalOptionsFunc app.AppOp
 	api.InitPost()
 	api.InitFile()
 	api.InitSystem()
+	api.InitCustomAlerts()
 	api.InitLicense()
 	api.InitConfig()
 	api.InitWebhook()

--- a/api4/custom_alerts.go
+++ b/api4/custom_alerts.go
@@ -1,0 +1,42 @@
+package api4
+
+import (
+	"fmt"
+	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/model"
+	"net/http"
+)
+
+func (api *API) InitCustomAlerts() {
+
+	api.BaseRoutes.ApiRoot.Handle("/custom_alerts", api.ApiSessionRequired(sendCustomAlertNotification)).Methods("POST")
+}
+
+func sendCustomAlertNotification(c *Context, w http.ResponseWriter, r *http.Request) {
+
+	if !c.App.SessionHasPermissionToSendAlerts(c.App.Session) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_JOBS)
+		mlog.Error(fmt.Sprintf("UserId: %v does not have permission to send alerts", c.App.Session.UserId))
+		return
+	}
+
+	if *c.App.Config().EmailSettings.SendPushNotifications {
+		pushServer := *c.App.Config().EmailSettings.PushNotificationServer
+		if license := c.App.License(); pushServer == model.MHPNS && (license == nil || !*license.Features.MHPNS) {
+			mlog.Warn("Push notifications are disabled. Go to System Console > Notifications > Mobile Push to enable them.")
+			return
+		}
+	}
+
+	notificationReq := model.CustomAlertRequestFromJson(r.Body)
+	if notificationReq == nil {
+		return
+	}
+
+	alertReqsChannel := c.App.GetChannelForCustomPushAlerts()
+	alertReqsChannel <- *notificationReq
+
+	mlog.Info("Custom alert request has been submitted to the worker pool")
+
+	ReturnStatusOK(w)
+}

--- a/api4/system.go
+++ b/api4/system.go
@@ -39,6 +39,7 @@ func (api *API) InitSystem() {
 
 	api.BaseRoutes.ApiRoot.Handle("/notifications/ack", api.ApiSessionRequired(pushNotificationAck)).Methods("POST")
 	api.BaseRoutes.ApiRoot.Handle("/telemetry/mobile", api.ApiSessionRequired(collectMobileTelemetry)).Methods("POST")
+
 }
 
 func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/app/authorization.go
+++ b/app/authorization.go
@@ -252,3 +252,14 @@ func (a *App) SessionHasPermissionToManageBot(session model.Session, botUserId s
 
 	return nil
 }
+
+func (a *App) SessionHasPermissionToSendAlerts(session model.Session) bool {
+
+	mlog.Info(fmt.Sprintf("Checking if UserId: %v has permission to send custom alerts", a.Session.UserId))
+
+	if a.SessionHasPermissionTo(session, model.PERMISSION_MANAGE_JOBS) {
+		return true
+	}
+
+	return false
+}

--- a/app/custom_alerts.go
+++ b/app/custom_alerts.go
@@ -1,0 +1,130 @@
+package app
+
+import (
+	"fmt"
+	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/model"
+)
+
+type CustomAlertsJob struct {
+	Channel chan model.CustomAlertRequest
+}
+
+func (s *Server) InitCustomAlerts() {
+	if *s.Config().EmailSettings.EnableCustomAlerts {
+
+		alertReqsChannel := make(chan model.CustomAlertRequest)
+		customAlertsJob := CustomAlertsJob{
+			Channel: alertReqsChannel,
+		}
+		s.FakeApp().StartCustomAlertsWorker(alertReqsChannel)
+		s.CustomAlertsJob = customAlertsJob
+	}
+}
+
+func (a *App) StartCustomAlertsWorker(alertRequests chan model.CustomAlertRequest) {
+	mlog.Debug("Starting the worker for custom push alerts")
+	a.Srv.Go(func() { a.customAlertsWorker(alertRequests) })
+}
+
+func (a *App) GetChannelForCustomPushAlerts() chan model.CustomAlertRequest {
+	return a.Srv.CustomAlertsJob.Channel;
+}
+
+func (s *Server) StopCustomAlertsJob() {
+	channel := s.CustomAlertsJob.Channel
+	close(channel)
+	mlog.Debug("Stopped the worker for custom push alerts")
+}
+
+func (a *App) customAlertsWorker(customAlertRequests chan model.CustomAlertRequest) {
+	mlog.Debug("Worker initialized for custom alerts job")
+
+	for alertReq := range customAlertRequests {
+		mlog.Info("processing new custom alert request")
+		postInfo, channelInfo := a.validateNewAlertRequest(alertReq)
+
+		if !*alertReq.SendPushNotification || postInfo == nil || channelInfo == nil {
+			continue
+		}
+
+		a.processAlert(alertReq, postInfo, channelInfo)
+	}
+}
+
+func (a *App) validateNewAlertRequest(alertReq model.CustomAlertRequest) (*model.Post, *model.Channel) {
+
+	if alertReq.PostId == nil || *alertReq.PostId == "" {
+		mlog.Error("Invalid Request, Mandatory fields are missing - 'postId' ")
+		return nil, nil
+	}
+
+	postInfo, err := a.GetSinglePost(*alertReq.PostId)
+	if err != nil {
+		mlog.Error(fmt.Sprintf("No valid Post data found for the postId: %v", *alertReq.PostId))
+		return nil, nil
+	}
+
+	channelInfo, err := a.GetChannel(postInfo.ChannelId)
+	if err != nil {
+		mlog.Error(fmt.Sprintf("No valid Channel data found for the channelId: %v", postInfo.ChannelId))
+		return postInfo, nil
+	}
+
+	if channelInfo.Type != model.CHANNEL_OPEN {
+		mlog.Error(fmt.Sprintf("Channel with Id: '%v', displayName: '%v' associated with the postId: %v is not open for all ",
+			channelInfo.Name, channelInfo.DisplayName, *alertReq.PostId))
+		return postInfo, nil
+	}
+
+	return postInfo, channelInfo
+}
+
+func (a *App) processAlert(alertRequest model.CustomAlertRequest, postInfo *model.Post, channelInfo *model.Channel) {
+
+	if *alertRequest.NotifyAllActiveUsers {
+
+		limit := 500
+		offset := 0
+
+		for userSessions, err := a.GetAllSessionsWithActiveDeviceIds(limit, offset); err == nil && len(userSessions) > 0; {
+			mlog.Info(fmt.Sprintf("processing %v active device sessions in current batch", len(userSessions)))
+			a.sendPushNotificationForActiveSessions(userSessions, alertRequest, channelInfo, postInfo)
+			offset = offset + limit
+		}
+
+	} else {
+
+		for _, userId := range *alertRequest.UserIds {
+			userSessions, err := a.GetMobileAppSessions(userId)
+			if err != nil {
+				mlog.Error("Unable to get mobile sessions for userId:"+userId, mlog.Err(err))
+				continue
+			}
+
+			a.sendPushNotificationForActiveSessions(userSessions, alertRequest, channelInfo, postInfo)
+
+		}
+	}
+
+}
+
+func (a *App) sendPushNotificationForActiveSessions(userSessions []*model.Session, notificationReq model.CustomAlertRequest,
+	channelInfo *model.Channel, postInfo *model.Post) {
+
+	for _, session := range userSessions {
+		mlog.Info(fmt.Sprintf("processing the active session for userId: %v", session.UserId))
+
+		if session.IsExpired() {
+			continue
+		}
+
+		deviceId := session.DeviceId
+		userInfo, _ := a.GetUser(session.UserId)
+
+		if deviceId != "" && *notificationReq.SendPushNotification {
+			a.SendCustomAlertToPushNotificationHub(postInfo, userInfo, channelInfo, notificationReq.CustomMessage, session)
+		}
+
+	}
+}

--- a/app/server.go
+++ b/app/server.go
@@ -70,6 +70,7 @@ type Server struct {
 	HubsStopCheckingForDeadlock chan bool
 
 	PushNotificationsHub PushNotificationsHub
+	CustomAlertsJob      CustomAlertsJob
 
 	runjobs bool
 	Jobs    *jobs.JobServer
@@ -205,6 +206,9 @@ func NewServer(options ...Option) (*Server, error) {
 		s.InitEmailBatching()
 	})
 
+	//Start the worker for processing custom push alerts request
+	s.InitCustomAlerts()
+
 	// Start plugin health check job
 	pluginsEnvironment := s.PluginsEnvironment
 	if pluginsEnvironment != nil {
@@ -336,6 +340,7 @@ func (s *Server) Shutdown() error {
 	mlog.Info("Stopping Server...")
 
 	s.RunOldAppShutdown()
+	s.StopCustomAlertsJob()
 
 	s.StopHTTPServer()
 	s.WaitForGoroutines()

--- a/app/session.go
+++ b/app/session.go
@@ -101,6 +101,15 @@ func (a *App) GetSessions(userId string) ([]*model.Session, *model.AppError) {
 
 }
 
+func (a *App) GetAllSessionsWithActiveDeviceIds(limit int, offset int) ([]*model.Session, *model.AppError) {
+	result := <-a.Srv.Store.Session().GetAllSessionsWithActiveDeviceIds(limit, offset)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	return result.Data.([]*model.Session), nil
+
+}
+
 func (a *App) RevokeAllSessions(userId string) *model.AppError {
 	result := <-a.Srv.Store.Session().GetSessions(userId)
 	if result.Err != nil {

--- a/model/config.go
+++ b/model/config.go
@@ -1136,6 +1136,7 @@ type EmailSettings struct {
 	LoginButtonColor                  *string
 	LoginButtonBorderColor            *string
 	LoginButtonTextColor              *string
+	EnableCustomAlerts                *bool
 }
 
 func (s *EmailSettings) SetDefaults() {
@@ -1269,6 +1270,10 @@ func (s *EmailSettings) SetDefaults() {
 
 	if s.LoginButtonTextColor == nil {
 		s.LoginButtonTextColor = NewString("#2389D7")
+	}
+
+	if s.EnableCustomAlerts == nil {
+		s.EnableCustomAlerts = NewBool(true)
 	}
 }
 

--- a/model/custom_alert.go
+++ b/model/custom_alert.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type CustomAlertRequest struct {
+	UserIds               *StringArray     `json:"user_ids"`
+	Props                 *StringInterface `json:"props"`
+	SendEmailNotification *bool            `json:"send_email_notification"`
+	SendPushNotification  *bool            `json:"send_push_notification"`
+	PostId                *string          `json:"post_id"`
+	CustomMessage         *string          `json:"custom_message"`
+	NotifyAllActiveUsers  *bool            `json:"notify_all_active_users"`
+}
+
+func CustomAlertRequestFromJson(data io.Reader) *CustomAlertRequest {
+	var o *CustomAlertRequest
+	json.NewDecoder(data).Decode(&o)
+	return o
+}

--- a/store/store.go
+++ b/store/store.go
@@ -317,6 +317,7 @@ type SessionStore interface {
 	Get(sessionIdOrToken string) StoreChannel
 	GetSessions(userId string) StoreChannel
 	GetSessionsWithActiveDeviceIds(userId string) StoreChannel
+	GetAllSessionsWithActiveDeviceIds(limit int, offset int) StoreChannel
 	Remove(sessionIdOrToken string) StoreChannel
 	RemoveAllSessions() StoreChannel
 	PermanentDeleteSessionsByUser(teamId string) StoreChannel

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -66,6 +66,23 @@ func (_m *SessionStore) GetSessions(userId string) store.StoreChannel {
 	return r0
 }
 
+// GetAllSessionsWithActiveDeviceIds provides a mock function with given fields: limit, offset
+func (_m *SessionStore) GetAllSessionsWithActiveDeviceIds(limit int, offset int) store.StoreChannel {
+	ret := _m.Called(limit, offset)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(int, int) store.StoreChannel); ok {
+		r0 = rf(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+
 // GetSessionsWithActiveDeviceIds provides a mock function with given fields: userId
 func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userId string) store.StoreChannel {
 	ret := _m.Called(userId)


### PR DESCRIPTION
#### Summary
UCHAT-4659 API to send push notification alerts to active mobile users about new releases or announcements. 

New API Url:
http://localhost:8065/api/v4/custom_alerts

Sample Request to the API:

```
{
    "user_ids": [
        "jzzc1obwn38cdck1myaccpnbta"
    ],
    "send_email_notification": false,
    "send_push_notification": true,
    "notify_all_active_users": false,
    "post_id" : "1yg4a17iffgdpktyocmgsg646o",
    "custom_message": "New version of UChat available, check it out",
    "props": {}
}
```

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-4659
